### PR TITLE
Fixed "Module not found" Error on Linux.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,7 +1,19 @@
 .DS_STORE
+logs
 *.log
 
 node_modules
 
 dist
 coverage
+
+npm-debug.log*
+
+# npm cache
+.npm
+.node_repl_history
+
+# vim swap/undo
+*.un~
+*.swp
+*.swo

--- a/src/app/blog/components/add/index.async.jsx
+++ b/src/app/blog/components/add/index.async.jsx
@@ -7,7 +7,7 @@ import { Form, Input, Button } from 'antd'
 
 import * as blogActions from '../../actions/blog'
 import history from 'utils/history'
-import Message from 'utils/Message'
+import Message from 'utils/message'
 
 import styles from './styles/index.scss'
 

--- a/src/app/user/components/forgot/index.async.jsx
+++ b/src/app/user/components/forgot/index.async.jsx
@@ -6,7 +6,7 @@ import autobind from 'autobind-decorator'
 import { Form, Input, Button } from 'antd'
 
 import md5 from 'utils/md5'
-import Message from 'utils/Message'
+import Message from 'utils/message'
 
 import * as tokenActions from '../../actions/tokens'
 

--- a/src/app/user/components/login/index.async.jsx
+++ b/src/app/user/components/login/index.async.jsx
@@ -6,7 +6,7 @@ import autobind from 'autobind-decorator'
 import { Form, Input, Button } from 'antd'
 
 import md5 from 'utils/md5'
-import Message from 'utils/Message'
+import Message from 'utils/message'
 
 import * as tokenActions from '../../actions/tokens'
 

--- a/src/app/user/components/logout/index.async.jsx
+++ b/src/app/user/components/logout/index.async.jsx
@@ -6,7 +6,7 @@ import autobind from 'autobind-decorator'
 import { Form, Input, Button } from 'antd'
 
 import md5 from 'utils/md5'
-import Message from 'utils/Message'
+import Message from 'utils/message'
 
 import * as tokenActions from '../../actions/tokens'
 

--- a/src/app/user/components/register/index.async.jsx
+++ b/src/app/user/components/register/index.async.jsx
@@ -6,7 +6,7 @@ import autobind from 'autobind-decorator'
 import { Form, Input, Button } from 'antd'
 
 import md5 from 'utils/md5'
-import Message from 'utils/Message'
+import Message from 'utils/message'
 
 import * as tokenActions from '../../actions/tokens'
 


### PR DESCRIPTION
The filename case of util/message.jsx doesn't match that of the import statement, which breaks the app on Linux.